### PR TITLE
Allow to increment with next

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ $version = Version::fromString('v1.3.2');
 
 $newVersion = $version->increase('major');  // v2.0.0
 $newVersion = $version->increase('minor');  // v1.4.0
+$newVersion = $version->increase('next');   // v1.4.0
 $newVersion = $version->increase('patch');  // v1.3.3
 $newVersion = $version->increase('stable'); // v1.4.0
 
@@ -54,6 +55,7 @@ $version = Version::fromString('v1.4.0-BETA1');
 $newVersion = $version->increase('beta');   // v1.4.0-BETA2
 $newVersion = $version->increase('rc');     // v1.4.0-RC1
 $newVersion = $version->increase('major');  // v1.4.0
+$newVersion = $version->increase('next');   // v1.4.0-BETA2
 $newVersion = $version->increase('stable'); // v1.4.0
 
 // Version validation

--- a/src/Version.php
+++ b/src/Version.php
@@ -202,11 +202,15 @@ final class Version
             case 'stable':
                 return $this->increaseStable();
 
+            case 'next':
+                return $this->increaseNext();
+
             default:
                 throw new \InvalidArgumentException(
                     sprintf(
-                        'Unknown stability "%s", accepts "%s" '.$stability,
-                        implode('", "', ['alpha', 'beta', 'rc', 'stable', 'major', 'minor', 'patch'])
+                        'Unknown stability "%s", accepts "%s".',
+                        $stability,
+                        implode('", "', ['alpha', 'beta', 'rc', 'stable', 'major', 'next', 'minor', 'patch'])
                     )
                 );
         }
@@ -229,6 +233,15 @@ final class Version
     {
         if ($this->stability < 3) {
             return new self(max($this->major, 1), 0, 0, 3);
+        }
+
+        return new self($this->major, $this->minor + 1, 0, 3);
+    }
+
+    private function increaseNext(): Version
+    {
+        if ($this->major > 0 && $this->stability < 3) {
+            return new self($this->major, $this->minor, $this->patch, $this->stability, $this->metaver + 1);
         }
 
         return new self($this->major, $this->minor + 1, 0, 3);

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -156,6 +156,13 @@ class VersionTest extends TestCase
             'major from 1.0' => ['1.0.0', '2.0.0', 'major'],
             'major from 2.0-beta' => ['2.0.0-beta1', '2.0.0', 'major'],
 
+            // Next
+            'new next from 0.1.0' => ['0.1.0', '0.2.0', 'next'],
+            'new next from 0.1.1' => ['0.1.1', '0.2.0', 'next'],
+            'new next from alpha' => ['1.0.0-alpha6', '1.0.0-alpha7', 'next'],
+            'new next from beta' => ['1.0.0-beta1', '1.0.0-beta2', 'next'],
+            'new next from current stable' => ['1.0.0', '1.1.0', 'next'],
+
             // Alpha
             'next alpha' => ['1.0.0-alpha1', '1.0.0-alpha2', 'alpha'],
             'new alpha' => ['1.0.0', '1.1.0-alpha1', 'alpha'],


### PR DESCRIPTION
When the current version is stable increment minor.
For unstable with metaver increment the metaver instead.