### PR TITLE
Increment metaver for patch increment

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,14 @@ $newVersion = $version->increase('rc');    // v1.4.0-RC1
 
 // ...
 // Increasing minor or patch is prohibited until the meta-ver (alpha,beta,rc) is 0
+// For patch this resolves to "next".
 
 $version = Version::fromString('v1.4.0-BETA1');
 $newVersion = $version->increase('beta');   // v1.4.0-BETA2
 $newVersion = $version->increase('rc');     // v1.4.0-RC1
 $newVersion = $version->increase('major');  // v1.4.0
 $newVersion = $version->increase('next');   // v1.4.0-BETA2
+$newVersion = $version->increase('patch');  // v1.4.0-BETA2
 $newVersion = $version->increase('stable'); // v1.4.0
 
 // Version validation

--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,10 @@
         "psr-4": {
             "Rollerworks\\Component\\Version\\Tests\\": "tests/"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.2-dev"
+        }
     }
 }

--- a/src/Version.php
+++ b/src/Version.php
@@ -168,7 +168,7 @@ final class Version
      *
      * Note. Using 'major' on a beta release will create a stable release
      * for that major version. Using 'stable' on an existing stable will increase
-     * minor.
+     * minor. Using 'patch' on an unstable release will increase the metaver instead.
      *
      * @param string $stability Eg. alpha, beta, rc, stable, major, minor, patch
      *
@@ -179,7 +179,7 @@ final class Version
         switch ($stability) {
             case 'patch':
                 if ($this->major > 0 && $this->metaver > 0) {
-                    throw new \InvalidArgumentException('Cannot increase patch for an unstable version.');
+                    return $this->increaseNext();
                 }
 
                 return new self($this->major, $this->minor, $this->patch + 1, 3);

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -143,6 +143,12 @@ class VersionTest extends TestCase
         return [
             'patch with patch 0' => ['0.1.0', '0.1.1', 'patch'],
             'patch with patch 1' => ['0.1.1', '0.1.2', 'patch'],
+            'patch with patch stable' => ['1.0.0', '1.0.1', 'patch'],
+
+            // Patch with unstable. Increase metaver instead
+            'patch with patch alpha' => ['1.0.0-alpha1', '1.0.0-alpha2', 'patch'],
+            'patch with patch beta' => ['1.0.0-beta1', '1.0.0-beta2', 'patch'],
+            'patch with patch rc' => ['1.0.0-rc1', '1.0.0-rc2', 'patch'],
 
             // Minor, patch must be reset
             'minor with patch 0' => ['0.1.0', '0.2.0', 'minor'],
@@ -196,11 +202,11 @@ class VersionTest extends TestCase
     }
 
     /** @test */
-    public function it_cannot_increases_patch_on_unstable()
+    public function it_cannot_increases_for_unsupported()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot increase patch for an unstable version.');
+        $this->expectExceptionMessage('Unknown stability "next-stable", accepts "alpha", "beta", "rc", "stable", "major", "next", "minor", "patch".');
 
-        Version::fromString('1.0.0-beta1')->increase('patch');
+        Version::fromString('1.0.0-beta1')->increase('next-stable');
     }
 }


### PR DESCRIPTION
When incrementing with ‘patch’ and the current stability is unstable increment the metaver while keeping all other segments intact.

1.0.0-alpha1 becomes 1.0.0-alpha2 for patch.

BC break: Previously this threw an exception.

Happy birthday Sebastiaan Stok 😄