### PR TITLE
Fix minor ver when major already exists now valid

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
     test:
         name: PHP ${{ matrix.php-versions }}
-        runs-on: ubuntu-18.04
+        runs-on: 'ubuntu-latest'
         strategy:
             fail-fast: false
             matrix:
@@ -21,14 +21,14 @@ jobs:
             # https://github.com/actions/checkout (official)
             -
                 name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v4
 
             # https://github.com/shivammathur/setup-php (community)
             -
                 name: Setup PHP and composer with shivammathur/setup-php
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: ${{ matrix.php-versions }}
+                    php-version: '${{ matrix.php-versions }}'
                     coverage: none
 
             # —— Composer 🧙‍️ —————————————————————————————————————————————————————————
@@ -42,13 +42,13 @@ jobs:
                 run: vendor/bin/phpunit --disallow-test-output --verbose
     phpstan:
         name: PHPStan
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-latest'
         strategy:
             fail-fast: false
         steps:
             -
                 name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v4
 
             # https://github.com/shivammathur/setup-php (community)
             -

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
         "php": "^7.1|^8.0"
     },
      "require-dev": {
-         "phpunit/phpunit": "^7.3.2|^8.5.12",
+         "phpunit/phpunit": "^7.3.2|^8.5.12|^9.6",
          "phpstan/phpstan": "^0.12.33",
          "phpstan/phpstan-phpunit": "^0.12.13",
-         "symfony/phpunit-bridge": "^5.2"
+         "symfony/phpunit-bridge": "^5.2 || ^6.4"
      },
     "autoload": {
         "psr-4": {

--- a/src/ContinuesVersionsValidator.php
+++ b/src/ContinuesVersionsValidator.php
@@ -116,10 +116,14 @@ final class ContinuesVersionsValidator
         return key($array);
     }
 
-    private function hasNewerVersionsAfter(int $major, int $minor): bool
+    private function hasNewerMajorVersionsAfter(int $major): bool
     {
-        return $this->getLastArrayIndex($this->resolveVersions) > $major ||
-               $this->getLastArrayIndex($this->resolveVersions[$major]) > $minor;
+        return $this->getLastArrayIndex($this->resolveVersions) > $major;
+    }
+
+    private function hasNewerMinorVersionsAfter(int $major, int $minor): bool
+    {
+        return $this->getLastArrayIndex($this->resolveVersions[$major]) > $minor;
     }
 
     private function computePossibleVersionsFromMinor(int $major, int $minor): void
@@ -127,8 +131,14 @@ final class ContinuesVersionsValidator
         /** @var Version $version */
         $version = $this->resolveVersions[$major][$minor];
 
-        if ($this->hasNewerVersionsAfter($major, $minor)) {
+        if ($this->hasNewerMinorVersionsAfter($major, $minor)) {
             $this->possibleVersions = [$version->getNextIncreaseOf('patch')];
+
+            return;
+        }
+
+        if ($this->hasNewerMajorVersionsAfter($major)) {
+            $this->possibleVersions = [$version->getNextIncreaseOf('patch'), $version->getNextIncreaseOf('minor')];
 
             return;
         }

--- a/tests/ContinuesVersionsValidatorTest.php
+++ b/tests/ContinuesVersionsValidatorTest.php
@@ -63,7 +63,7 @@ class ContinuesVersionsValidatorTest extends TestCase
         yield 'unstable #6' => ['1.0-BETA1', ['0.2', '0.1'], ['0.2.1', '0.3', '1.0-BETA1', '1.0']];
 
         yield 'stable #1' => ['1.2', ['1.0', '1.1'], ['1.1.1', '1.2-BETA1', '1.2', '2.0-ALPHA1', '2.0-BETA1', '2.0']];
-        yield 'stable #2' => ['1.1.1', ['1.1', '2.0'], ['1.1.1']];
+        yield 'stable #2' => ['1.1.1', ['1.1', '2.0'], ['1.1.1', '1.2.0']];
     }
 
     /**
@@ -77,7 +77,7 @@ class ContinuesVersionsValidatorTest extends TestCase
     {
         $validator = new ContinuesVersionsValidator(...$this->createVersions($existing));
 
-        self::assertTrue($validator->isContinues(Version::fromString($new)));
+        self::assertTrue($validator->isContinues(Version::fromString($new)), sprintf('Excepts instead %s', implode(',', $validator->getPossibleVersions())));
         self::assertEquals($this->createVersions($possible), array_merge([], $validator->getPossibleVersions()));
     }
 
@@ -129,7 +129,7 @@ class ContinuesVersionsValidatorTest extends TestCase
     }
 
     /**
-     * @return array<string, array<int, string[]|string>>
+     * @return iterable<string, array<int, string[]|string>>
      */
     public function provideNonContinuesVersions(): iterable
     {
@@ -142,6 +142,7 @@ class ContinuesVersionsValidatorTest extends TestCase
 
         yield 'stable #1' => ['1.3', ['1.0', '1.1'], ['1.1.1', '1.2-BETA1', '1.2', '2.0-ALPHA1', '2.0-BETA1', '2.0']];
         yield 'stable #2' => ['3.6', ['v3.5-beta1'], ['v3.5-beta2', 'v3.5-RC1', 'v3.5']];
+        yield 'stable #3 ' => ['3.6', ['v3.4', 'v3.7'], ['3.7.1', '3.8.0-BETA1', '3.8.0', '4.0.0-ALPHA1', '4.0.0-BETA1', '4.0.0']];
     }
 
     /**

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -167,6 +167,7 @@ class VersionTest extends TestCase
             // Minor, patch must be reset
             'minor with patch 0' => ['0.1.0', '0.2.0', 'minor'],
             'minor with patch 1' => ['0.1.1', '0.2.0', 'minor'],
+            'minor with new minor' => ['1.1.2', '1.2.0', 'minor'],
 
             // Major, minor and patch must be reset
             'major.0.0' => ['0.1.0', '1.0.0', 'major'],


### PR DESCRIPTION
When a new minor version was given but a newer major version already exists the new minor version was considered non-continues. This is fixed now.