### PR TITLE
Fix loosing minor version with beta to stable

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -257,15 +257,20 @@ final class Version
             return new self($this->major, $this->minor, 0, self::$stabilityIndexes[$stability], 1);
         }
 
+        // Lower stability than current.
         return new self($this->major, $this->minor + 1, 0, self::$stabilityIndexes[$stability], 1);
     }
 
     private function getIncreaseOfStable(): self
     {
-        if ($this->stability < self::STABILITY_STABLE) {
-            return new self(max($this->major, 1), 0, 0, self::STABILITY_STABLE);
+        if ($this->stability === self::STABILITY_STABLE) {
+            return new self($this->major, $this->minor + 1, 0, self::STABILITY_STABLE);
         }
 
-        return new self($this->major, $this->minor + 1, 0, self::STABILITY_STABLE);
+        if ($this->major === 0) {
+            return new self(1, 0, 0, self::STABILITY_STABLE);
+        }
+
+        return new self($this->major, $this->minor, 0, self::STABILITY_STABLE);
     }
 }

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -181,6 +181,7 @@ class VersionTest extends TestCase
             'new next from 0.1.0' => ['0.1.0', '0.2.0', 'next'],
             'new next from 0.1.1' => ['0.1.1', '0.2.0', 'next'],
             'new next from alpha' => ['1.0.0-alpha6', '1.0.0-alpha7', 'next'],
+            'new next from alpha 2' => ['1.2.0-alpha6', '1.2.0-alpha7', 'next'],
             'new next from beta' => ['1.0.0-beta1', '1.0.0-beta2', 'next'],
             'new next from current stable' => ['1.0.0', '1.1.0', 'next'],
 
@@ -203,6 +204,7 @@ class VersionTest extends TestCase
             'new stable from 0.0' => ['0.1.0', '1.0.0', 'stable'],
             'new stable from alpha' => ['1.0.0-alpha6', '1.0.0', 'stable'],
             'new stable from beta' => ['1.0.0-beta1', '1.0.0', 'stable'],
+            'new stable from beta 2' => ['1.2.0-beta1', '1.2.0', 'stable'],
             'new stable from current stable' => ['1.0.0', '1.1.0', 'stable'],
         ];
     }


### PR DESCRIPTION
Getting the next 'stable' for 1.2.0-BETA5 should produce 1.2.0 but produced 1.0
